### PR TITLE
add windows support

### DIFF
--- a/bondcpp/CMakeLists.txt
+++ b/bondcpp/CMakeLists.txt
@@ -7,9 +7,15 @@ find_package(catkin REQUIRED bond roscpp smclib)
 include_directories(SYSTEM ${BOOST_INCLUDE_DIRS})
 include_directories(include ${catkin_INCLUDE_DIRS})
 
+if(WIN32)
+  set(UUID_LIB "Rpcrt4")
+else()
+  set(UUID_LIB "uuid")
+endif()
+
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES ${PROJECT_NAME} uuid
+  LIBRARIES ${PROJECT_NAME} ${UUID_LIB}
   CATKIN_DEPENDS bond roscpp smclib
   DEPENDS Boost
 )
@@ -19,7 +25,8 @@ add_library(${PROJECT_NAME}
   src/bond.cpp
   src/BondSM_sm.cpp
 )
-target_link_libraries(${PROJECT_NAME} uuid ${catkin_LIBRARIES} ${BOOST_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${UUID_LIB} ${catkin_LIBRARIES} ${BOOST_LIBRARIES})
+
 if(catkin_EXPORTED_TARGETS)
   add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 endif()

--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -32,17 +32,32 @@
 #include <bondcpp/bond.h>
 #include <boost/thread/thread_time.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
+
+#ifdef _WIN32
+#include <Rpc.h>
+#else
 #include <uuid/uuid.h>
+#endif
 
 namespace bond {
 
 static std::string makeUUID()
 {
+#ifdef _WIN32
+  UUID uuid;
+  UuidCreate(&uuid);
+  unsigned char *str;
+  UuidToStringA(&uuid, &str);
+  std::string return_string((char*)str);
+  RpcStringFreeA(&str);
+  return return_string;
+#else
   uuid_t uuid;
   uuid_generate_random(uuid);
   char uuid_str[40];
   uuid_unparse(uuid, uuid_str);
   return std::string(uuid_str);
+#endif
 }
 
 Bond::Bond(const std::string &topic, const std::string &id,


### PR DESCRIPTION
Modified bondcpp to build on Windows.  The uuid library does not exist on windows, but similar functionality is available through the rpcrt4 library.
