### PR TITLE
bondpy: Add catkin_package call to CMakeLists.txt

### DIFF
--- a/bondpy/CMakeLists.txt
+++ b/bondpy/CMakeLists.txt
@@ -4,3 +4,5 @@ project(bondpy)
 find_package(catkin REQUIRED)
 
 catkin_python_setup()
+
+catkin_package()


### PR DESCRIPTION
If catkin_package is not called, the package.xml is not installed

See https://github.com/ros/catkin/issues/622
