### PR TITLE
Export architecture_independent flag in package.xml

### DIFF
--- a/bond/package.xml
+++ b/bond/package.xml
@@ -21,4 +21,8 @@
 
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/bondpy/package.xml
+++ b/bondpy/package.xml
@@ -21,4 +21,8 @@
   <run_depend>rospy</run_depend>
   <run_depend>smclib</run_depend>
   <run_depend>uuid</run_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/smclib/package.xml
+++ b/smclib/package.xml
@@ -17,4 +17,8 @@
   <url type="repository">https://github.com/ros/bond_core</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>


### PR DESCRIPTION
This package doesn't have any binaries in it, so it can be marked as architecture independent.

Tested on the RPM buildfarm (http://csc.mcs.sdsmt.edu/jenkins/):
- [x] No regressions
- [x] No binaries installed

See:
- https://github.com/ros/rosdistro/issues/4037
- https://github.com/ros-infrastructure/bloom/pull/270
- http://www.ros.org/reps/rep-0127.html#architecture-independent

Thanks!
