### PR TITLE
fix -isystem /usr/include build breakage in gcc6

### DIFF
--- a/bondcpp/CMakeLists.txt
+++ b/bondcpp/CMakeLists.txt
@@ -5,8 +5,7 @@ find_package(Boost REQUIRED)
 find_package(catkin REQUIRED bond cmake_modules roscpp smclib)
 find_package(UUID REQUIRED)
 
-include_directories(SYSTEM ${BOOST_INCLUDE_DIRS})
-include_directories(include ${catkin_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 catkin_package(
   INCLUDE_DIRS include

--- a/test_bond/CMakeLists.txt
+++ b/test_bond/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(catkin REQUIRED COMPONENTS bondcpp genmsg rostest)
 
 if(CATKIN_ENABLE_TESTING)
   include_directories(${GTEST_INCLUDE_DIRS})
-  include_directories(SYSTEM ${bondcpp_INCLUDE_DIRS})
+  include_directories(include ${bondcpp_INCLUDE_DIRS})
 
   # create the service
   add_service_files(DIRECTORY srv FILES TestBond.srv)


### PR DESCRIPTION
relates to https://github.com/ros/rosdistro/issues/12783