### PR TITLE
Use SteadyTime and SteadyTimer for bond timeouts

### DIFF
--- a/bondcpp/include/bondcpp/bond.h
+++ b/bondcpp/include/bondcpp/bond.h
@@ -167,7 +167,7 @@ private:
 
   ros::Subscriber sub_;
   ros::Publisher pub_;
-  ros::WallTimer publishingTimer_;
+  ros::SteadyTimer publishingTimer_;
 
   void onConnectTimeout();
   void onHeartbeatTimeout();
@@ -175,7 +175,7 @@ private:
 
   void bondStatusCB(const bond::Status::ConstPtr &msg);
 
-  void doPublishing(const ros::WallTimerEvent &e);
+  void doPublishing(const ros::SteadyTimerEvent &e);
   void publishStatus(bool active);
 
   std::vector<boost::function<void(void)> > pending_callbacks_;

--- a/bondcpp/include/bondcpp/timeout.h
+++ b/bondcpp/include/bondcpp/timeout.h
@@ -55,12 +55,12 @@ public:
 
 private:
   ros::NodeHandle nh_;
-  ros::WallTimer timer_;
+  ros::SteadyTimer timer_;
   ros::SteadyTime deadline_;
   ros::WallDuration duration_;
   boost::function<void(void)> on_timeout_;
 
-  void timerCallback(const ros::WallTimerEvent &e);
+  void timerCallback(const ros::SteadyTimerEvent &e);
 };
 
 

--- a/bondcpp/include/bondcpp/timeout.h
+++ b/bondcpp/include/bondcpp/timeout.h
@@ -56,7 +56,7 @@ public:
 private:
   ros::NodeHandle nh_;
   ros::WallTimer timer_;
-  ros::WallTime deadline_;
+  ros::SteadyTime deadline_;
   ros::WallDuration duration_;
   boost::function<void(void)> on_timeout_;
 

--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -202,7 +202,7 @@ bool Bond::waitUntilFormed(ros::Duration timeout)
 bool Bond::waitUntilFormed(ros::WallDuration timeout)
 {
   boost::mutex::scoped_lock lock(mutex_);
-  ros::WallTime deadline(ros::WallTime::now() + timeout);
+  ros::SteadyTime deadline(ros::SteadyTime::now() + timeout);
 
   while (sm_.getState().getId() == SM::WaitingForSister.getId()) {
     if (!ros::ok()) {
@@ -211,7 +211,7 @@ bool Bond::waitUntilFormed(ros::WallDuration timeout)
 
     ros::WallDuration wait_time = ros::WallDuration(0.1);
     if (timeout >= ros::WallDuration(0.0)) {
-      wait_time = std::min(wait_time, deadline - ros::WallTime::now());
+      wait_time = std::min(wait_time, deadline - ros::SteadyTime::now());
     }
 
     if (wait_time <= ros::WallDuration(0.0)) {
@@ -230,16 +230,17 @@ bool Bond::waitUntilBroken(ros::Duration timeout)
 bool Bond::waitUntilBroken(ros::WallDuration timeout)
 {
   boost::mutex::scoped_lock lock(mutex_);
-  ros::WallTime deadline(ros::WallTime::now() + timeout);
+  ros::SteadyTime deadline(ros::SteadyTime::now() + timeout);
 
-  while (sm_.getState().getId() != SM::Dead.getId()) {
-    if (!ros::ok()) {
+  while (sm_.getState().getId() != SM::Dead.getId())
+  {
+    if (!ros::ok())
       break;
     }
 
-    ros::WallDuration wait_time = ros::WallDuration(0.1);
+    ros::SteadyTime deadline(ros::SteadyTime::now() + timeout);
     if (timeout >= ros::WallDuration(0.0)) {
-      wait_time = std::min(wait_time, deadline - ros::WallTime::now());
+      wait_time = std::min(wait_time, deadline - ros::SteadyTime::now());
     }
 
     if (wait_time <= ros::WallDuration(0.0)) {

--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -178,7 +178,7 @@ void Bond::start()
   pub_ = nh_.advertise<bond::Status>(topic_, 5);
   sub_ = nh_.subscribe<bond::Status>(topic_, 30, boost::bind(&Bond::bondStatusCB, this, _1));
 
-  publishingTimer_ = nh_.createWallTimer(
+  publishingTimer_ = nh_.createSteadyTimer(
     ros::WallDuration(heartbeat_period_), &Bond::doPublishing, this);
   started_ = true;
 }
@@ -338,7 +338,7 @@ void Bond::bondStatusCB(const bond::Status::ConstPtr &msg)
   }
 }
 
-void Bond::doPublishing(const ros::WallTimerEvent &)
+void Bond::doPublishing(const ros::SteadyTimerEvent &)
 {
   boost::mutex::scoped_lock lock(mutex_);
   if (sm_.getState().getId() == SM::WaitingForSister.getId() ||

--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -232,13 +232,12 @@ bool Bond::waitUntilBroken(ros::WallDuration timeout)
   boost::mutex::scoped_lock lock(mutex_);
   ros::SteadyTime deadline(ros::SteadyTime::now() + timeout);
 
-  while (sm_.getState().getId() != SM::Dead.getId())
-  {
-    if (!ros::ok())
+  while (sm_.getState().getId() != SM::Dead.getId()) {
+    if (!ros::ok()) {
       break;
     }
 
-    ros::SteadyTime deadline(ros::SteadyTime::now() + timeout);
+    ros::WallDuration wait_time = ros::WallDuration(0.1);
     if (timeout >= ros::WallDuration(0.0)) {
       wait_time = std::min(wait_time, deadline - ros::SteadyTime::now());
     }

--- a/bondcpp/src/timeout.cpp
+++ b/bondcpp/src/timeout.cpp
@@ -64,7 +64,7 @@ void Timeout::setDuration(const ros::WallDuration &d)
 void Timeout::reset()
 {
   timer_.stop();
-  timer_ = nh_.createWallTimer(duration_, &Timeout::timerCallback, this, true);
+  timer_ = nh_.createSteadyTimer(duration_, &Timeout::timerCallback, this, true);
   deadline_ = ros::SteadyTime::now() + duration_;
 }
 
@@ -78,7 +78,7 @@ ros::WallDuration Timeout::left()
   return std::max(ros::WallDuration(0.0), deadline_ - ros::SteadyTime::now());
 }
 
-void Timeout::timerCallback(const ros::WallTimerEvent &)
+void Timeout::timerCallback(const ros::SteadyTimerEvent &)
 {
   if (on_timeout_) {
     on_timeout_();

--- a/bondcpp/src/timeout.cpp
+++ b/bondcpp/src/timeout.cpp
@@ -65,7 +65,7 @@ void Timeout::reset()
 {
   timer_.stop();
   timer_ = nh_.createWallTimer(duration_, &Timeout::timerCallback, this, true);
-  deadline_ = ros::WallTime::now() + duration_;
+  deadline_ = ros::SteadyTime::now() + duration_;
 }
 
 void Timeout::cancel()
@@ -75,7 +75,7 @@ void Timeout::cancel()
 
 ros::WallDuration Timeout::left()
 {
-  return std::max(ros::WallDuration(0.0), deadline_ - ros::WallTime::now());
+  return std::max(ros::WallDuration(0.0), deadline_ - ros::SteadyTime::now());
 }
 
 void Timeout::timerCallback(const ros::WallTimerEvent &)


### PR DESCRIPTION
Fixes #16 

Depends on ros/roscpp_core#57 and ros/ros_comm#1014

Tested and working on Ubuntu14.04/Indigo.