### PR TITLE
Fixes problem with bondpy not exiting with the node

### DIFF
--- a/bondpy/python/bondpy/bondpy.py
+++ b/bondpy/python/bondpy/bondpy.py
@@ -52,12 +52,14 @@ class Timeout:
     def __init__(self, duration, on_timeout=None):
         self.duration = duration
         self.timer = threading.Timer(0, self._on_timer)
+        self.timer.daemon = True
         self.deadline = time.time()
         self.on_timeout = on_timeout
 
     def reset(self):
         self.timer.cancel()
         self.timer = threading.Timer(self.duration.to_sec(), self._on_timer)
+        self.timer.daemon = True
         self.timer.start()
         self.deadline = time.time() + self.duration.to_sec()
         return self


### PR DESCRIPTION
Currently, if the main thread exits (e.g. with a ROSInterruptException) while one of these timer threads is still running, the node does not exit.  Making these daemons causes them to exit with the main thread, allowing the node to shut down in a timely manner without requiring a SIGKILL.

This has been tested and fixes the above problem in several Python nodes that depend on bondpy.