### PR TITLE
make package.xml to comply with schema

### DIFF
--- a/bond/package.xml
+++ b/bond/package.xml
@@ -9,12 +9,13 @@
     connected until it is either broken explicitly or until a
     heartbeat times out.
   </description>
-  <author>Stuart Glaser</author>
   <maintainer email="mikael@osrfoundation.org">Mikael Arguedas</maintainer>
   <license>BSD</license>
+
   <url type="website">http://www.ros.org/wiki/bond</url>
   <url type="bugtracker">https://github.com/ros/bond_core/issues</url>
   <url type="repository">https://github.com/ros/bond_core</url>
+  <author>Stuart Glaser</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/bondcpp/package.xml
+++ b/bondcpp/package.xml
@@ -7,12 +7,13 @@
     C++ implementation of bond, a mechanism for checking when
     another process has terminated.
   </description>
-  <author>Stuart Glaser</author>
   <maintainer email="mikael@osrfoundation.org">Mikael Arguedas</maintainer>
   <license>BSD</license>
+
   <url type="website">http://www.ros.org/wiki/bondcpp</url>
   <url type="bugtracker">https://github.com/ros/bond_core/issues</url>
   <url type="repository">https://github.com/ros/bond_core</url>
+  <author>Stuart Glaser</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/bondpy/package.xml
+++ b/bondpy/package.xml
@@ -7,12 +7,13 @@
     Python implementation of bond, a mechanism for checking when
     another process has terminated.
   </description>
-  <author>Stuart Glaser</author>
   <maintainer email="mikael@osrfoundation.org">Mikael Arguedas</maintainer>
   <license>BSD</license>
+
   <url type="website">http://www.ros.org/wiki/bondpy</url>
   <url type="bugtracker">https://github.com/ros/bond_core/issues</url>
   <url type="repository">https://github.com/ros/bond_core</url>
+  <author>Stuart Glaser</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/smclib/package.xml
+++ b/smclib/package.xml
@@ -11,12 +11,13 @@
     This package contains the libraries that a compiled state machine
     depends on, but it does not contain the compiler itself.
   </description>
-  <author>Various</author>
   <maintainer email="mikael@osrfoundation.org">Mikael Arguedas</maintainer>
   <license>Mozilla Public License Version 1.1</license>
+
   <url type="website">http://smc.sourceforge.net/</url>
   <url type="bugtracker">https://github.com/ros/bond_core/issues</url>
   <url type="repository">https://github.com/ros/bond_core</url>
+  <author>Various</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/test_bond/package.xml
+++ b/test_bond/package.xml
@@ -6,12 +6,13 @@
   <description>
      Contains tests for [[bond]], including tests for [[bondpy]] and [[bondcpp]].
   </description>
-  <author>Stuart Glaser</author>
   <maintainer email="mikael@osrfoundation.org">Mikael Arguedas</maintainer>
   <license>BSD</license>
+
   <url type="website">http://www.ros.org/wiki/test_bond</url>
   <url type="bugtracker">https://github.com/ros/bond_core/issues</url>
   <url type="repository">https://github.com/ros/bond_core</url>
+  <author>Stuart Glaser</author>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 


### PR DESCRIPTION
Investigating XML issue I noticed that these package didn't pass xmllint. Now they validate the schema: http://download.ros.org/schema/package_format2.xsd