### PR TITLE
uuid dependency fixup

### DIFF
--- a/bondcpp/CMakeLists.txt
+++ b/bondcpp/CMakeLists.txt
@@ -5,11 +5,16 @@ find_package(Boost REQUIRED)
 find_package(catkin REQUIRED bond cmake_modules roscpp smclib)
 find_package(UUID REQUIRED)
 
-include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
+  ${UUID_INCLUDE_DIRS}
+)
 
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES ${PROJECT_NAME} ${UUID_LIBRARIES}
+  LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS bond roscpp smclib
   DEPENDS Boost
 )

--- a/test_bond/CMakeLists.txt
+++ b/test_bond/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(test_bond)
 
-find_package(catkin REQUIRED COMPONENTS bondcpp genmsg rostest)
+find_package(catkin REQUIRED COMPONENTS cmake_modules bondcpp message_generation rostest)
 
 if(CATKIN_ENABLE_TESTING)
   include_directories(${GTEST_INCLUDE_DIRS})
@@ -17,8 +17,10 @@ catkin_package()
 
 if(CATKIN_ENABLE_TESTING)
   # add more tests
+  find_package(UUID REQUIRED)
+  include_directories(${UUID_INCLUDE_DIRS})
   add_executable(exercise_bond EXCLUDE_FROM_ALL test/exercise_bond.cpp)
-  target_link_libraries(exercise_bond ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
+  target_link_libraries(exercise_bond ${catkin_LIBRARIES} ${GTEST_LIBRARIES} ${UUID_LIBRARIES})
   if(test_bond_EXPORTED_TARGETS)
     add_dependencies(exercise_bond ${test_bond_EXPORTED_TARGETS})
   endif()
@@ -28,7 +30,7 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest(test/test_python.launch)
 
   add_executable(test_callbacks_cpp EXCLUDE_FROM_ALL test/test_callbacks_cpp.cpp)
-  target_link_libraries(test_callbacks_cpp ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
+  target_link_libraries(test_callbacks_cpp ${catkin_LIBRARIES} ${GTEST_LIBRARIES} ${UUID_LIBRARIES})
   if(test_bond_EXPORTED_TARGETS)
     add_dependencies(test_callbacks_cpp ${test_bond_EXPORTED_TARGETS})
   endif()

--- a/test_bond/package.xml
+++ b/test_bond/package.xml
@@ -17,8 +17,10 @@
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <build_depend>bondcpp</build_depend>
-  <build_depend>genmsg</build_depend>
+  <build_depend>cmake_modules</build_depend>
+  <build_depend>message_generation</build_depend>
   <build_depend>rostest</build_depend>
 
   <test_depend>bondpy</test_depend>
+  <test_depend>uuid</test_depend>
 </package>


### PR DESCRIPTION
dont export uuid dependency as this isnt anywhere in the public api.

Context: https://github.com/ros/bond_core/issues/35

Should be backported to indigo-devel as well