### PR TITLE
Argument to Boost Milliseconds must be integral in Boost >= 1.67

### DIFF
--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -218,7 +218,8 @@ bool Bond::waitUntilFormed(ros::WallDuration timeout)
       break;  // The deadline has expired
     }
 
-    condition_.timed_wait(mutex_, boost::posix_time::milliseconds(wait_time.toSec() * 1000.0f));
+    condition_.timed_wait(mutex_, boost::posix_time::milliseconds(
+                static_cast<int>(wait_time.toSec() * 1000.0f)));
   }
   return sm_.getState().getId() != SM::WaitingForSister.getId();
 }
@@ -246,7 +247,8 @@ bool Bond::waitUntilBroken(ros::WallDuration timeout)
       break;  // The deadline has expired
     }
 
-    condition_.timed_wait(mutex_, boost::posix_time::milliseconds(wait_time.toSec() * 1000.0f));
+    condition_.timed_wait(mutex_, boost::posix_time::milliseconds(
+                static_cast<int>(wait_time.toSec() * 1000.0f)));
   }
   return sm_.getState().getId() == SM::Dead.getId();
 }

--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -219,7 +219,7 @@ bool Bond::waitUntilFormed(ros::WallDuration timeout)
     }
 
     condition_.timed_wait(mutex_, boost::posix_time::milliseconds(
-      static_cast<int>(wait_time.toSec() * 1000.0f)));
+      static_cast<int64_t>(wait_time.toSec() * 1000.0f)));
   }
   return sm_.getState().getId() != SM::WaitingForSister.getId();
 }
@@ -248,7 +248,7 @@ bool Bond::waitUntilBroken(ros::WallDuration timeout)
     }
 
     condition_.timed_wait(mutex_, boost::posix_time::milliseconds(
-      static_cast<int>(wait_time.toSec() * 1000.0f)));
+      static_cast<int64_t>(wait_time.toSec() * 1000.0f)));
   }
   return sm_.getState().getId() == SM::Dead.getId();
 }

--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -219,7 +219,7 @@ bool Bond::waitUntilFormed(ros::WallDuration timeout)
     }
 
     condition_.timed_wait(mutex_, boost::posix_time::milliseconds(
-                static_cast<int>(wait_time.toSec() * 1000.0f)));
+      static_cast<int>(wait_time.toSec() * 1000.0f)));
   }
   return sm_.getState().getId() != SM::WaitingForSister.getId();
 }
@@ -248,7 +248,7 @@ bool Bond::waitUntilBroken(ros::WallDuration timeout)
     }
 
     condition_.timed_wait(mutex_, boost::posix_time::milliseconds(
-                static_cast<int>(wait_time.toSec() * 1000.0f)));
+      static_cast<int>(wait_time.toSec() * 1000.0f)));
   }
   return sm_.getState().getId() == SM::Dead.getId();
 }


### PR DESCRIPTION
With the last version of Boost the compilation of `bondcpp` fails because of non-matching types in the call to `boost::posix_time::milliseconds`. See https://github.com/ros/roscpp_core/pull/79.