### PR TITLE
Solved static linking problems with bondcpp

### DIFF
--- a/bondcpp/CMakeLists.txt
+++ b/bondcpp/CMakeLists.txt
@@ -16,7 +16,7 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS bond roscpp smclib
-  DEPENDS Boost
+  DEPENDS Boost UUID
 )
 
 add_library(${PROJECT_NAME}


### PR DESCRIPTION
Static linking against bondcpp failed because UUID wasn't exported in the DEPENDS list.
This solves the issue.