### PR TITLE
remove windows.h to avoid namespace pollution

### DIFF
--- a/smclib/include/smclib/statemap.h
+++ b/smclib/include/smclib/statemap.h
@@ -52,7 +52,6 @@
 #include <cstdio>
 #elif defined(WIN32)
 #include <iostream>
-#include <windows.h>
 #if defined(SMC_NO_EXCEPTIONS)
 #include <cassert>
 #endif  // SMC_NO_EXCEPTIONS


### PR DESCRIPTION
remove the unused `windows.h` to avoid namespace pollution