### PR TITLE
use STL in place of Boost

### DIFF
--- a/bondcpp/CMakeLists.txt
+++ b/bondcpp/CMakeLists.txt
@@ -19,10 +19,15 @@ catkin_package(
   DEPENDS Boost
 )
 
+# ROS Melodic: http://www.ros.org/reps/rep-0003.html
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
 add_library(${PROJECT_NAME}
-  src/timeout.cpp
   src/bond.cpp
   src/BondSM_sm.cpp
+  src/timeout.cpp
 )
 target_link_libraries(${PROJECT_NAME} ${UUID_LIBRARIES} ${catkin_LIBRARIES} ${BOOST_LIBRARIES})
 

--- a/bondcpp/include/bondcpp/bond.h
+++ b/bondcpp/include/bondcpp/bond.h
@@ -45,6 +45,8 @@
 #include "BondSM_sm.h"
 
 #include <string>
+#include <functional>
+#include <mutex>
 #include <vector>
 
 #ifdef ROS_BUILD_SHARED_LIBS // ros is being built around shared libraries
@@ -77,8 +79,8 @@ public:
    * \param on_formed callback that will be called when the bond is formed.
    */
   Bond(const std::string &topic, const std::string &id,
-       boost::function<void(void)> on_broken = boost::function<void(void)>(),
-       boost::function<void(void)> on_formed = boost::function<void(void)>());
+       std::function<void(void)> on_broken = nullptr,
+       std::function<void(void)> on_formed = nullptr);
 
   /** \brief Destructs the object, breaking the bond if it is still formed.
    */
@@ -101,11 +103,11 @@ public:
 
   /** \brief Sets the formed callback.
    */
-  void setFormedCallback(boost::function<void(void)> on_formed);
+  void setFormedCallback(const std::function<void(void)>& on_formed);
 
   /** \brief Sets the broken callback
    */
-  void setBrokenCallback(boost::function<void(void)> on_broken);
+  void setBrokenCallback(const std::function<void(void)>& on_broken);
 
   /** \brief Blocks until the bond is formed for at most 'duration'.
    *
@@ -152,19 +154,19 @@ private:
   friend class ::BondSM;
 
   ros::NodeHandle nh_;
-  boost::scoped_ptr<BondSM> bondsm_;
+  std::unique_ptr<BondSM> bondsm_;
   BondSMContext sm_;
 
   std::string topic_;
   std::string id_;
   std::string instance_id_;
   std::string sister_instance_id_;
-  boost::function<void(void)> on_broken_;
-  boost::function<void(void)> on_formed_;
+  std::function<void(void)> on_broken_;
+  std::function<void(void)> on_formed_;
   bool sisterDiedFirst_;
   bool started_;
 
-  boost::mutex mutex_;
+  std::mutex mutex_;
   boost::condition condition_;
 
   double connect_timeout_;
@@ -189,7 +191,7 @@ private:
   void doPublishing(const ros::SteadyTimerEvent &e);
   void publishStatus(bool active);
 
-  std::vector<boost::function<void(void)> > pending_callbacks_;
+  std::vector<std::function<void(void)> > pending_callbacks_;
   void flushPendingCallbacks();
 };
 

--- a/bondcpp/include/bondcpp/bond.h
+++ b/bondcpp/include/bondcpp/bond.h
@@ -32,10 +32,6 @@
 #ifndef BONDCPP__BOND_H_
 #define BONDCPP__BOND_H_
 
-#include <boost/scoped_ptr.hpp>
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/condition.hpp>
-
 #include <ros/ros.h>
 #include <ros/macros.h>
 
@@ -44,9 +40,10 @@
 #include <bond/Status.h>
 #include "BondSM_sm.h"
 
-#include <string>
+#include <condition_variable>
 #include <functional>
 #include <mutex>
+#include <string>
 #include <vector>
 
 #ifdef ROS_BUILD_SHARED_LIBS // ros is being built around shared libraries

--- a/bondcpp/include/bondcpp/bond.h
+++ b/bondcpp/include/bondcpp/bond.h
@@ -167,7 +167,7 @@ private:
   bool started_;
 
   std::mutex mutex_;
-  boost::condition condition_;
+  std::condition_variable condition_;
 
   double connect_timeout_;
   double heartbeat_timeout_;

--- a/bondcpp/include/bondcpp/timeout.h
+++ b/bondcpp/include/bondcpp/timeout.h
@@ -30,6 +30,8 @@
 #ifndef BONDCPP__TIMEOUT_H_
 #define BONDCPP__TIMEOUT_H_
 
+#include <functional>
+
 #include <ros/ros.h>
 
 namespace bond {
@@ -37,12 +39,8 @@ namespace bond {
 class Timeout
 {
 public:
-  Timeout(
-    const ros::Duration &d,
-    boost::function<void(void)> on_timeout = boost::function<void(void)>());
-  Timeout(
-    const ros::WallDuration &d,
-    boost::function<void(void)> on_timeout = boost::function<void(void)>());
+  Timeout(const ros::Duration &d, std::function<void(void)> on_timeout = nullptr);
+  Timeout(const ros::WallDuration &d, std::function<void(void)> on_timeout = nullptr);
   ~Timeout();
 
   // Undefined what these do to a running timeout
@@ -58,7 +56,7 @@ private:
   ros::SteadyTimer timer_;
   ros::SteadyTime deadline_;
   ros::WallDuration duration_;
-  boost::function<void(void)> on_timeout_;
+  std::function<void(void)> on_timeout_;
 
   void timerCallback(const ros::SteadyTimerEvent &e);
 };

--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -39,6 +39,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <condition_variable>
 #include <functional>
 #include <mutex>
 #include <string>

--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -40,6 +40,7 @@
 #endif
 
 #include <algorithm>
+#include <funcional>
 #include <string>
 #include <vector>
 
@@ -79,9 +80,9 @@ Bond::Bond(const std::string &topic, const std::string &id,
   sisterDiedFirst_(false),
   started_(false),
 
-  connect_timer_(ros::WallDuration(), boost::bind(&Bond::onConnectTimeout, this)),
-  heartbeat_timer_(ros::WallDuration(), boost::bind(&Bond::onHeartbeatTimeout, this)),
-  disconnect_timer_(ros::WallDuration(), boost::bind(&Bond::onDisconnectTimeout, this))
+  connect_timer_(ros::WallDuration(), std::bind(&Bond::onConnectTimeout, this)),
+  heartbeat_timer_(ros::WallDuration(), std::bind(&Bond::onHeartbeatTimeout, this)),
+  disconnect_timer_(ros::WallDuration(), std::bind(&Bond::onDisconnectTimeout, this))
 {
   setConnectTimeout(bond::Constants::DEFAULT_CONNECT_TIMEOUT);
   setDisconnectTimeout(bond::Constants::DEFAULT_DISCONNECT_TIMEOUT);
@@ -176,7 +177,7 @@ void Bond::start()
   boost::mutex::scoped_lock lock(mutex_);
   connect_timer_.reset();
   pub_ = nh_.advertise<bond::Status>(topic_, 5);
-  sub_ = nh_.subscribe<bond::Status>(topic_, 30, boost::bind(&Bond::bondStatusCB, this, _1));
+  sub_ = nh_.subscribe<bond::Status>(topic_, 30, std::bind(&Bond::bondStatusCB, this, std::placeholders::_1));
 
   publishingTimer_ = nh_.createSteadyTimer(
     ros::WallDuration(heartbeat_period_), &Bond::doPublishing, this);

--- a/bondcpp/src/timeout.cpp
+++ b/bondcpp/src/timeout.cpp
@@ -30,17 +30,16 @@
 #include "bondcpp/timeout.h"
 
 #include <algorithm>
+#include <functional>
 
 namespace bond {
 
-Timeout::Timeout(const ros::Duration &d,
-                 boost::function<void(void)> on_timeout)
+Timeout::Timeout(const ros::Duration &d, std::function<void(void)> on_timeout)
   : duration_(d.sec, d.nsec), on_timeout_(on_timeout)
 {
 }
 
-Timeout::Timeout(const ros::WallDuration &d,
-                 boost::function<void(void)> on_timeout)
+Timeout::Timeout(const ros::WallDuration &d, std::function<void(void)> on_timeout)
   : duration_(d), on_timeout_(on_timeout)
 {
 }


### PR DESCRIPTION
with ROS Melodic pushing C++ support to c++14, a series of STL libraries including `std::bind`, `std::mutex`, `std::unique_lock` can now be used to build a modern C++ code base

this change requires at least c++11; therefore, this repo needs to branch off for a melodic branch

this change likely needs to be updated after https://github.com/ros/bond_core/pull/52 gets merged