### PR TITLE
Bump CMake minimum version to use CMP0048

### DIFF
--- a/bond/CMakeLists.txt
+++ b/bond/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(bond)
 
 find_package(catkin REQUIRED message_generation std_msgs)

--- a/bond_core/CMakeLists.txt
+++ b/bond_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(bond_core)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/bondcpp/CMakeLists.txt
+++ b/bondcpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(bondcpp)
 
 find_package(Boost REQUIRED)

--- a/bondpy/CMakeLists.txt
+++ b/bondpy/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(bondpy)
 
 find_package(catkin REQUIRED)

--- a/smclib/CMakeLists.txt
+++ b/smclib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(smclib)
 
 find_package(catkin REQUIRED)

--- a/test_bond/CMakeLists.txt
+++ b/test_bond/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(test_bond)
 


### PR DESCRIPTION
Fixes the corresponding CMake warning.

See ros/catkin#1052

Signed-off-by: Michael Carroll <michael@openrobotics.org>