### PR TITLE
import setup from setuptools instead of distutils-core

### DIFF
--- a/bondpy/setup.py
+++ b/bondpy/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 from catkin_pkg.python_setup import generate_distutils_setup
 

--- a/smclib/setup.py
+++ b/smclib/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 from catkin_pkg.python_setup import generate_distutils_setup
 


### PR DESCRIPTION
Following the guidelines to migrate packages to [noetic](http://wiki.ros.org/noetic/Migration)

 - import setup from setuptools instead of distutils-core

Signed-off-by: ahcorde <ahcorde@gmail.com>