### PR TITLE
[noetic] Use setuptools instead of distutils

### DIFF
--- a/bondpy/package.xml
+++ b/bondpy/package.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>bondpy</name>
   <version>1.8.4</version>
   <description>
@@ -24,6 +26,9 @@
   <exec_depend>rospy</exec_depend>
   <exec_depend>smclib</exec_depend>
   <exec_depend>uuid</exec_depend>
+
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <export>
     <architecture_independent/>

--- a/bondpy/setup.py
+++ b/bondpy/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 from catkin_pkg.python_setup import generate_distutils_setup
 

--- a/smclib/package.xml
+++ b/smclib/package.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>smclib</name>
   <version>1.8.4</version>
   <description>
@@ -20,6 +22,8 @@
   <author>Various</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <export>
     <architecture_independent/>

--- a/smclib/setup.py
+++ b/smclib/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 from catkin_pkg.python_setup import generate_distutils_setup
 


### PR DESCRIPTION
Use setuptools instead of distutils

Since ros/catkin#1048 catkin prefers to use setuptools instead of distutils. The package.xml doesn't need to include python3-setuptools because [catkin exports that dependency](https://github.com/ros/catkin/blob/86439ec5d2010d5c47c30b815aa97e525037930f/package.xml#L32) for the convenience of all downstream python packages.

Based on https://github.com/ros/genlisp/pull/17

Signed-off-by: ahcorde <ahcorde@gmail.com>