### PR TITLE
bondpy: Prevent exception in Bond.shutdown()

### DIFF
--- a/bondpy/python/bondpy/bondpy.py
+++ b/bondpy/python/bondpy/bondpy.py
@@ -119,6 +119,8 @@ class Bond(object):
         self.disconnect_timeout = Constants.DEFAULT_DISCONNECT_TIMEOUT
         self.heartbeat_period = Constants.DEFAULT_HEARTBEAT_PERIOD
 
+        self.sub = None
+
         # queue_size 1 : avoid having a client receive backed up, potentially
         # late heartbearts, discussion@https://github.com/ros/bond_core/pull/10
         self.pub = rospy.Publisher(self.topic, Status, queue_size=1)
@@ -198,7 +200,8 @@ class Bond(object):
 
     def shutdown(self):
         if not self.is_shutdown:
-            self.sub.unregister()
+            if self.sub is not None:
+                self.sub.unregister()
             with self.lock:
                 self.is_shutdown = True
                 if self.sm.getState().getName() != 'SM.Dead':

--- a/test_bond/test/exercise_bond.py
+++ b/test_bond/test/exercise_bond.py
@@ -148,6 +148,14 @@ class Exerciser(unittest.TestCase):
         self.assertFalse(bond.wait_until_broken(rospy.Duration(1.0)))
         self.assertTrue(bond.wait_until_broken(rospy.Duration(10.0)))
 
+    # Shutdown() before start()
+    def test_shutdown_before_start(self):
+        id = gen_id()
+        self.bond = bondpy.Bond(TOPIC, id)
+
+        self.bond.shutdown()
+        self.bond = None
+
     def setUp(self):
         self.bond = None
 


### PR DESCRIPTION
When Bond.shutdown() is called before Bond.start(), an exception is thrown:

E.g. in add_analyzers from diagnostics:

```
Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/core.py", line 568, in signal_shutdown
    h()
  File "/opt/ros/melodic/lib/diagnostic_aggregator/add_analyzers", line 22, in remove_group
    self.bond.shutdown()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/bondpy/bondpy.py", line 201, in shutdown
    self.sub.unregister()
AttributeError: 'Bond' object has no attribute 'sub'
```

This PR checks that sub exists before trying to unregister it.