### PR TITLE
narrow down required boost dependencies

### DIFF
--- a/bondcpp/CMakeLists.txt
+++ b/bondcpp/CMakeLists.txt
@@ -24,7 +24,7 @@ add_library(${PROJECT_NAME}
   src/bond.cpp
   src/BondSM_sm.cpp
 )
-target_link_libraries(${PROJECT_NAME} ${UUID_LIBRARIES} ${catkin_LIBRARIES} ${BOOST_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${UUID_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 if(catkin_EXPORTED_TARGETS)
   add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})

--- a/bondcpp/CMakeLists.txt
+++ b/bondcpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(bondcpp)
 
-find_package(Boost REQUIRED)
+find_package(Boost REQUIRED date_time thread)
 find_package(catkin REQUIRED bond cmake_modules roscpp smclib)
 find_package(UUID REQUIRED)
 

--- a/bondcpp/package.xml
+++ b/bondcpp/package.xml
@@ -20,7 +20,9 @@
   <build_depend version_gte="0.3.2">cmake_modules</build_depend>
 
   <depend>bond</depend>
-  <depend>boost</depend>
+  <depend>libboost-dev</depend>
+  <depend>libboost-date-time-dev</depend>
+  <depend>libboost-thread-dev</depend>
   <depend>roscpp</depend>
   <depend>smclib</depend>
   <depend>uuid</depend>


### PR DESCRIPTION
In an [ongoing effort](https://discourse.ros.org/t/generating-dev-and-runtime-artefacts-from-ros-packages/12448) to reduce the footprint on the target systems, it is preferred to declare specific dependencies instead of generic ones.

This also fixes `BOOST_LIBRARIES` -> `Boost_LIBRARIES` as `BOOST_LIBRARIES` is not set when finding boost