### PR TITLE
[Fixing CI] using chrono literals for durations from rclcpp API update

### DIFF
--- a/bondcpp/include/bondcpp/bond.hpp
+++ b/bondcpp/include/bondcpp/bond.hpp
@@ -38,6 +38,7 @@
 #include <mutex>
 #include <string>
 #include <vector>
+#include <chrono>
 
 #include "bond/msg/constants.hpp"
 #include "bond/msg/status.hpp"
@@ -46,6 +47,8 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+using namespace std::chrono_literals;
 
 namespace bond
 {
@@ -132,14 +135,14 @@ public:
    * \param timeout Maximum duration to wait.  If -1 then this call will not timeout.
    * \return true iff the bond has been formed.
    */
-  bool waitUntilFormed(rclcpp::Duration timeout = rclcpp::Duration(-1 * 1e9));
+  bool waitUntilFormed(rclcpp::Duration timeout = rclcpp::Duration(-1s));
   /** \brief Blocks until the bond is broken for at most 'duration'.
    *    Assumes the node to be spinning in the background
    *
    * \param timeout Maximum duration to wait.  If -1 then this call will not timeout.
    * \return true iff the bond has been broken, even if it has never been formed.
    */
-  bool waitUntilBroken(rclcpp::Duration timeout = rclcpp::Duration(-1 * 1e9));
+  bool waitUntilBroken(rclcpp::Duration timeout = rclcpp::Duration(-1s));
   /** \brief Indicates if the bond is broken.
    */
   bool isBroken();

--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -144,7 +144,7 @@ Bond::~Bond()
     return;
   }
   breakBond();
-  if (rclcpp::ok() && !waitUntilBroken(rclcpp::Duration(0.10 * 1e9))) {
+  if (rclcpp::ok() && !waitUntilBroken(rclcpp::Duration(100ms))) {
     RCLCPP_DEBUG(node_logging_->get_logger(), "Bond failed to break on destruction %s (%s)",
       id_.c_str(), instance_id_.c_str());
   }
@@ -399,12 +399,12 @@ bool Bond::waitUntilFormed(rclcpp::Duration timeout)
     if (!rclcpp::ok()) {
       break;
     }
-    rclcpp::Duration wait_time = rclcpp::Duration(0.1 * 1e9);
-    if (timeout >= rclcpp::Duration(0.0)) {
+    rclcpp::Duration wait_time = rclcpp::Duration(100ms);
+    if (timeout >= rclcpp::Duration(0.0s)) {
       rclcpp::Clock steady_clock(RCL_STEADY_TIME);
       wait_time = std::min(wait_time, deadline - steady_clock.now());
     }
-    if (wait_time <= rclcpp::Duration(0.0)) {
+    if (wait_time <= rclcpp::Duration(0.0s)) {
       break;  //  The deadline has expired
     }
     r.sleep();
@@ -424,12 +424,12 @@ bool Bond::waitUntilBroken(rclcpp::Duration timeout)
     if (!rclcpp::ok()) {
       break;
     }
-    rclcpp::Duration wait_time = rclcpp::Duration(0.1 * 1e9);
-    if (timeout >= rclcpp::Duration(0.0)) {
+    rclcpp::Duration wait_time = rclcpp::Duration(100ms);
+    if (timeout >= rclcpp::Duration(0.0s)) {
       rclcpp::Clock steady_clock(RCL_STEADY_TIME);
       wait_time = std::min(wait_time, deadline - steady_clock.now());
     }
-    if (wait_time <= rclcpp::Duration(0.0)) {
+    if (wait_time <= rclcpp::Duration(0.0s)) {
       break;  //  The deadline has expired
     }
     r.sleep();

--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -185,7 +185,7 @@ void Bond::setConnectTimeout(double dur)
 
 void Bond::connectTimerReset()
 {
-  rclcpp::Duration dur1(connect_timeout_);
+  rclcpp::Duration dur1(rclcpp::Duration::from_nanoseconds(connect_timeout_));
   const std::chrono::nanoseconds period1(dur1.nanoseconds());
   // Callback function of connect timer
   auto connectTimerResetCallback =
@@ -222,7 +222,7 @@ void Bond::setDisconnectTimeout(double dur)
 
 void Bond::disconnectTimerReset()
 {
-  rclcpp::Duration dur2(disconnect_timeout_);
+  rclcpp::Duration dur2(rclcpp::Duration::from_nanoseconds(disconnect_timeout_));
   const std::chrono::nanoseconds period2(dur2.nanoseconds());
   // Callback function of disconnect timer
   auto disconnectTimerResetCallback =
@@ -259,7 +259,7 @@ void Bond::setHeartbeatTimeout(double dur)
 
 void Bond::heartbeatTimerReset()
 {
-  rclcpp::Duration dur3(heartbeat_timeout_);
+  rclcpp::Duration dur3(rclcpp::Duration::from_nanoseconds(heartbeat_timeout_));
   const std::chrono::nanoseconds period3(dur3.nanoseconds());
   //  Callback function of heartbeat timer
   auto heartbeatTimerResetCallback =
@@ -296,7 +296,7 @@ void Bond::setHeartbeatPeriod(double dur)
 
 void Bond::publishingTimerReset()
 {
-  rclcpp::Duration dur4(heartbeat_period_);
+  rclcpp::Duration dur4(rclcpp::Duration::from_nanoseconds(heartbeat_period_));
   const std::chrono::nanoseconds period4(dur4.nanoseconds());
   //  Callback function of publishing timer
   auto publishingTimerResetCallback =
@@ -329,7 +329,7 @@ void Bond::setDeadPublishPeriod(double dur)
 
 void Bond::deadpublishingTimerReset()
 {
-  rclcpp::Duration dur5(dead_publish_period_);
+  rclcpp::Duration dur5(rclcpp::Duration::from_nanoseconds(dead_publish_period_));
   const std::chrono::nanoseconds period5(dur5.nanoseconds());
   //  callback function of dead publishing timer which will publish data when bond is broken
   auto deadpublishingTimerResetCallback =

--- a/test_bond/test/test_callbacks_cpp.cpp
+++ b/test_bond/test/test_callbacks_cpp.cpp
@@ -29,6 +29,7 @@
 
 #include <gtest/gtest.h>
 #include <string>
+#include <chrono>
 
 #ifndef _WIN32
 # include <uuid/uuid.h>
@@ -42,6 +43,8 @@
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
 #include "test_bond/srv/test_bond.hpp"
+
+using namespace std::chrono_literals;
 
 const char TOPIC[] = "test_bond_topic";
 std::string genId()
@@ -88,8 +91,8 @@ TEST_F(TestCallbacksCpp, dieInLifeCallback)
   a.start();
   b.start();
 
-  EXPECT_TRUE(a.waitUntilFormed(rclcpp::Duration(5.0)));
-  EXPECT_TRUE(b.waitUntilBroken(rclcpp::Duration(3.0)));
+  EXPECT_TRUE(a.waitUntilFormed(rclcpp::Duration(5.0s)));
+  EXPECT_TRUE(b.waitUntilBroken(rclcpp::Duration(3.0s)));
 }
 
 TEST_F(TestCallbacksCpp, remoteNeverConnects)
@@ -99,6 +102,6 @@ TEST_F(TestCallbacksCpp, remoteNeverConnects)
   bond::Bond a1(TOPIC, id2, nh2);
 
   a1.start();
-  EXPECT_FALSE(a1.waitUntilFormed(rclcpp::Duration(5.0)));
-  EXPECT_TRUE(a1.waitUntilBroken(rclcpp::Duration(10.0)));
+  EXPECT_FALSE(a1.waitUntilFormed(rclcpp::Duration(5.0s)));
+  EXPECT_TRUE(a1.waitUntilBroken(rclcpp::Duration(10.0s)));
 }


### PR DESCRIPTION
Per https://app.circleci.com/pipelines/github/ros-planning/navigation2/4121/workflows/80503470-8d6a-4e4f-bbee-65a65e1cab04/jobs/15663

```
/opt/ros/foxy/include/rclcpp/duration.hpp:46:12: note: declared here
   46 |   explicit Duration(rcl_duration_value_t nanoseconds);
      |            ^~~~~~~~
In file included from /opt/overlay_ws/src/navigation2/nav2_util/include/nav2_util/lifecycle_node.hpp:25,
                 from /opt/overlay_ws/src/navigation2/nav2_util/src/lifecycle_node.cpp:15:
/opt/underlay_ws/install/bondcpp/include/bondcpp/bond.hpp:142:76: error: ‘rclcpp::Duration::Duration(rcl_duration_value_t)’ is deprecated: Use Duration::from_nanoseconds instead or std::chrono_literals. For example:rclcpp::Duration::from_nanoseconds(int64_variable);rclcpp::Duration(0ns); [-Werror=deprecated-declarations]
  142 |   bool waitUntilBroken(rclcpp::Duration timeout = rclcpp::Duration(-1 * 1e9));
      |                                                                            ^
```

Bondcpp with ROS2 main is a little unhappy with the use of duration integers without `from_nanoseconds` (new) or chrono literals. I updated everything to use chrono literals. 

Using this job as a test https://app.circleci.com/jobs/github/ros-planning/navigation2/15671 that this removes the deprecation warning 