### PR TITLE
Fix use of boost::bind.

### DIFF
--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -30,6 +30,7 @@
 // Author: Stuart Glaser
 
 #include <bondcpp/bond.h>
+#include <boost/bind/bind.hpp>
 #include <boost/thread/thread_time.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 
@@ -176,7 +177,7 @@ void Bond::start()
   boost::mutex::scoped_lock lock(mutex_);
   connect_timer_.reset();
   pub_ = nh_.advertise<bond::Status>(topic_, 5);
-  sub_ = nh_.subscribe<bond::Status>(topic_, 30, boost::bind(&Bond::bondStatusCB, this, _1));
+  sub_ = nh_.subscribe<bond::Status>(topic_, 30, boost::bind(&Bond::bondStatusCB, this, boost::placeholders::_1));
 
   publishingTimer_ = nh_.createSteadyTimer(
     ros::WallDuration(heartbeat_period_), &Bond::doPublishing, this);


### PR DESCRIPTION
This PR adds a missing include statement.

Additionally, since boost 1.75, the use of placeholders in the global namespace is deprecated, so the PR also switches to qualified placeholders.