### PR TITLE
Add build dependencies on pkg-config.

### DIFF
--- a/bondcpp/package.xml
+++ b/bondcpp/package.xml
@@ -17,6 +17,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>bond</build_depend>
+  <build_depend>pkg-config</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rclcpp_lifecycle</build_depend>
   <build_depend>smclib</build_depend>

--- a/test_bond/package.xml
+++ b/test_bond/package.xml
@@ -31,6 +31,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>bond</test_depend>
   <test_depend>bondcpp</test_depend>
+  <test_depend>pkg-config</test_depend>
   <test_depend>rclcpp</test_depend>
   <test_depend>rclcpp_lifecycle</test_depend>
   <test_depend>uuid</test_depend>


### PR DESCRIPTION
This should fix the build on the buildfarm.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This is a backport of #73 for the dashing-devel branch.