### PR TITLE
Backport: Remove test_bond dependency from bond_core (#79)

### DIFF
--- a/bond_core/package.xml
+++ b/bond_core/package.xml
@@ -22,7 +22,6 @@
   <exec_depend>bondcpp</exec_depend>
   <!-- <exec_depend>bondpy</exec_depend>-->
   <exec_depend>smclib</exec_depend>
-  <exec_depend>test_bond</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Signed-off-by: Michael Carroll <michael@openrobotics.org>