### PR TITLE
Drop unused access specifiers

### DIFF
--- a/smclib/include/smclib/statemap.hpp
+++ b/smclib/include/smclib/statemap.hpp
@@ -105,7 +105,6 @@ class SmcException
 // Member methods
 //
 
-public:
 protected:
   // Constructor.
   explicit SmcException(const std::string & reason)
@@ -115,14 +114,6 @@ protected:
 private:
   // Default construction not allowed.
   SmcException();
-
-  // -----------------------------------------------------------
-  // Member data.
-  //
-
-public:
-protected:
-private:
 };
 
 // This class is thrown when a pop is issued on an empty
@@ -139,16 +130,6 @@ public:
   PopOnEmptyStateStackException()
   : SmcException("no state to pop from state stack")
   {}
-
-protected:
-private:
-  // -----------------------------------------------------------
-  // Member data.
-  //
-
-public:
-protected:
-private:
 };
 
 // This class is thrown when a transition is issued
@@ -167,16 +148,6 @@ public:
   StateUndefinedException()
   : SmcException("transition invoked while in transition")
   {}
-
-protected:
-private:
-  //  -----------------------------------------------------------
-  // Member data.
-  //
-
-public:
-protected:
-private:
 };
 
 // This class is thrown when a transition is issued
@@ -263,14 +234,6 @@ public:
     return _transition;
   }
 
-protected:
-private:
-  //  -----------------------------------------------------------
-  // Member data.
-  //
-
-public:
-protected:
 private:
   char * _state;
   char * _transition;
@@ -351,14 +314,6 @@ public:
     return _maxIndex;
   }
 
-protected:
-private:
-  // -----------------------------------------------------------
-  // Member data.
-  //
-
-public:
-protected:
 private:
   int _index;
   int _minIndex;
@@ -417,15 +372,12 @@ private:
 // Member data.
 //
 
-public:
 protected:
   // This state's printable name.
   char * _name;
 
   // This state's unique identifier.
   int _stateId;
-
-private:
 };
 
 class FSMContext
@@ -434,8 +386,6 @@ class FSMContext
 // Nested classes.
 //
 
-public:
-protected:
 private:
   // Implements the state stack.
   class StateEntry
@@ -466,14 +416,6 @@ public:
       return _next;
     }
 
-protected:
-private:
-    //-------------------------------------------------------
-    // Member data.
-    //
-
-public:
-protected:
 private:
     State * _state;
     StateEntry * _next;
@@ -743,7 +685,6 @@ private:
 // Member data
 //
 
-public:
 protected:
   // The current state of the finite state machine.
   State * _state;

--- a/test_bond/CMakeLists.txt
+++ b/test_bond/CMakeLists.txt
@@ -42,8 +42,9 @@ if(BUILD_TESTING)
     target_include_directories(test_callbacks_cpp PRIVATE include)
     target_link_libraries(test_callbacks_cpp ${uuid_ABS_PATH})
     ament_target_dependencies(test_callbacks_cpp bond bondcpp rclcpp rclcpp_lifecycle)
-    rosidl_target_interfaces(test_callbacks_cpp
-      ${PROJECT_NAME} "rosidl_typesupport_cpp")
+
+    rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
+    target_link_libraries(test_callbacks_cpp "${cpp_typesupport_target}")
   endif()
 
   #  ament_add_gtest(test_callbacks_cpp_exc test/test_callbacks_cpp_exc.cpp)


### PR DESCRIPTION
These cannot satisfy both cpplint and uncrustify and are generally just noise.

Signed-off-by: Michael Carroll <michael@openrobotics.org>