### PR TITLE
Bond cleanups

### DIFF
--- a/bondcpp/include/bondcpp/bond.hpp
+++ b/bondcpp/include/bondcpp/bond.hpp
@@ -44,8 +44,8 @@
 
 #include "bondcpp/BondSM_sm.hpp"
 
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
 
 namespace bond
 {
@@ -189,12 +189,18 @@ private:
   void onHeartbeatTimeout();
   void onDisconnectTimeout();
 
-  void bondStatusCB(const bond::msg::Status::ConstSharedPtr msg);
+  void bondStatusCB(const bond::msg::Status & msg);
 
   void doPublishing();
   void publishStatus(bool active);
 
   void flushPendingCallbacks();
+
+  bool isStateAlive();
+  bool isStateAwaitSisterDeath();
+  bool isStateDead();
+  bool isStateWaitingForSister();
+
 
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_;

--- a/bondcpp/include/bondcpp/bond.hpp
+++ b/bondcpp/include/bondcpp/bond.hpp
@@ -33,7 +33,6 @@
 #define BONDCPP__BOND_HPP_
 
 #include <chrono>
-#include <condition_variable>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -192,7 +191,6 @@ private:
   bool deadpublishing_timer_reset_flag_;
   bool disable_heartbeat_timeout_;
   std::mutex mutex_;
-  std::condition_variable condition_;
 
   double connect_timeout_;
   double heartbeat_timeout_;

--- a/bondcpp/include/bondcpp/bond.hpp
+++ b/bondcpp/include/bondcpp/bond.hpp
@@ -184,7 +184,6 @@ private:
   void doPublishing();
   void publishStatus(bool active);
 
-  std::vector<EventCallback> pending_callbacks_;
   void flushPendingCallbacks();
 
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
@@ -197,6 +196,7 @@ private:
   rclcpp::TimerBase::SharedPtr publishing_timer_;
   rclcpp::TimerBase::SharedPtr deadpublishing_timer_;
 
+  std::mutex state_machine_mutex_;
   std::unique_ptr<BondSM> bondsm_;
   BondSMContext sm_;
 
@@ -204,6 +204,9 @@ private:
   std::string id_;
   std::string instance_id_;
   std::string sister_instance_id_;
+
+  std::mutex callbacks_mutex_;
+  std::vector<EventCallback> pending_callbacks_;
   EventCallback on_broken_;
   EventCallback on_formed_;
 
@@ -213,7 +216,6 @@ private:
   bool disconnect_timer_reset_flag_ {false};
   bool deadpublishing_timer_reset_flag_ {false};
   bool disable_heartbeat_timeout_ {false};
-  std::mutex mutex_;
 
   double connect_timeout_;
   double heartbeat_timeout_;

--- a/bondcpp/include/bondcpp/bond.hpp
+++ b/bondcpp/include/bondcpp/bond.hpp
@@ -60,7 +60,6 @@ class Bond
 public:
   using EventCallback = std::function<void (void)>;
 
-private:
   /** \brief Constructor to delegate common functionality
    *
    * \param topic The topic used to exchange the bond status messages.
@@ -78,10 +77,10 @@ private:
     rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
     rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_params,
     rclcpp::node_interfaces::NodeTimersInterface::SharedPtr node_timers,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
     EventCallback on_broken = EventCallback(),
     EventCallback on_formed = EventCallback());
 
-public:
   /** \brief Constructs a bond, but does not connect
    *
    * \param topic The topic used to exchange the bond status messages.
@@ -116,6 +115,8 @@ public:
    */
   ~Bond();
 
+  void setupConnections();
+
   double getConnectTimeout() const {return connect_timeout_;}
   void setConnectTimeout(double dur);
   void connectTimerReset();
@@ -140,6 +141,7 @@ public:
   /** \brief Starts the bond and connects to the sister process.
    */
   void start();
+
   /** \brief Sets the formed callback.
    */
   void setFormedCallback(EventCallback on_formed);
@@ -155,6 +157,7 @@ public:
    * \return true iff the bond has been formed.
    */
   bool waitUntilFormed(rclcpp::Duration timeout = rclcpp::Duration(std::chrono::seconds(-1)));
+
   /** \brief Blocks until the bond is broken for at most 'duration'.
    *    Assumes the node to be spinning in the background
    *
@@ -162,12 +165,15 @@ public:
    * \return true iff the bond has been broken, even if it has never been formed.
    */
   bool waitUntilBroken(rclcpp::Duration timeout = rclcpp::Duration(std::chrono::seconds(-1)));
+
   /** \brief Indicates if the bond is broken.
    */
   bool isBroken();
+
   /** \brief Breaks the bond, notifying the other process.
    */
   void breakBond();
+
   std::string getTopic() {return topic_;}
   std::string getId() {return id_;}
   std::string getInstanceId() {return instance_id_;}

--- a/bondcpp/include/bondcpp/bond.hpp
+++ b/bondcpp/include/bondcpp/bond.hpp
@@ -59,6 +59,29 @@ class Bond
 {
 public:
   using EventCallback = std::function<void (void)>;
+
+private:
+  /** \brief Constructor to delegate common functionality
+   *
+   * \param topic The topic used to exchange the bond status messages.
+   * \param id The ID of the bond, which should match the ID used on
+   *           the sister's end.
+   * \param node_base base node interface
+   * \param node_logging logging node interface
+   * \param node_timers timers node interface
+   * \param on_broken callback that will be called when the bond is broken.
+   * \param on_formed callback that will be called when the bond is formed.
+   */
+  Bond(
+    const std::string & topic, const std::string & id,
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_params,
+    rclcpp::node_interfaces::NodeTimersInterface::SharedPtr node_timers,
+    EventCallback on_broken = EventCallback(),
+    EventCallback on_formed = EventCallback());
+
+public:
   /** \brief Constructs a bond, but does not connect
    *
    * \param topic The topic used to exchange the bond status messages.
@@ -92,8 +115,6 @@ public:
   /** \brief Destructs the object, breaking the bond if it is still formed.
    */
   ~Bond();
-
-  void setupConnections();
 
   double getConnectTimeout() const {return connect_timeout_;}
   void setConnectTimeout(double dur);
@@ -167,8 +188,8 @@ private:
   void flushPendingCallbacks();
 
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
-  rclcpp::node_interfaces::NodeTimersInterface::SharedPtr node_timers_;
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_;
+  rclcpp::node_interfaces::NodeTimersInterface::SharedPtr node_timers_;
 
   rclcpp::TimerBase::SharedPtr connect_timer_;
   rclcpp::TimerBase::SharedPtr disconnect_timer_;
@@ -186,12 +207,12 @@ private:
   EventCallback on_broken_;
   EventCallback on_formed_;
 
-  bool sisterDiedFirst_;
-  bool started_;
-  bool connect_timer_reset_flag_;
-  bool disconnect_timer_reset_flag_;
-  bool deadpublishing_timer_reset_flag_;
-  bool disable_heartbeat_timeout_;
+  bool sisterDiedFirst_ {false};
+  bool started_ {false};
+  bool connect_timer_reset_flag_ {false};
+  bool disconnect_timer_reset_flag_ {false};
+  bool deadpublishing_timer_reset_flag_ {false};
+  bool disable_heartbeat_timeout_ {false};
   std::mutex mutex_;
 
   double connect_timeout_;

--- a/bondcpp/include/bondcpp/bond.hpp
+++ b/bondcpp/include/bondcpp/bond.hpp
@@ -58,6 +58,7 @@ namespace bond
 class Bond
 {
 public:
+  using EventCallback = std::function<void (void)>;
   /** \brief Constructs a bond, but does not connect
    *
    * \param topic The topic used to exchange the bond status messages.
@@ -70,8 +71,8 @@ public:
   Bond(
     const std::string & topic, const std::string & id,
     rclcpp_lifecycle::LifecycleNode::SharedPtr nh,
-    std::function<void(void)> on_broken = std::function<void(void)>(),
-    std::function<void(void)> on_formed = std::function<void(void)>());
+    EventCallback on_broken = EventCallback(),
+    EventCallback on_formed = EventCallback());
 
   /** \brief Constructs a bond, but does not connect
    *
@@ -85,8 +86,8 @@ public:
   Bond(
     const std::string & topic, const std::string & id,
     rclcpp::Node::SharedPtr nh,
-    std::function<void(void)> on_broken = std::function<void(void)>(),
-    std::function<void(void)> on_formed = std::function<void(void)>());
+    EventCallback on_broken = EventCallback(),
+    EventCallback on_formed = EventCallback());
 
   /** \brief Destructs the object, breaking the bond if it is still formed.
    */
@@ -120,11 +121,11 @@ public:
   void start();
   /** \brief Sets the formed callback.
    */
-  void setFormedCallback(std::function<void(void)> on_formed);
+  void setFormedCallback(EventCallback on_formed);
 
   /** \brief Sets the broken callback
    */
-  void setBrokenCallback(std::function<void(void)> on_broken);
+  void setBrokenCallback(EventCallback on_broken);
 
   /** \brief Blocks until the bond is formed for at most 'duration'.
    *    Assumes the node to be spinning in the background
@@ -162,7 +163,7 @@ private:
   void doPublishing();
   void publishStatus(bool active);
 
-  std::vector<std::function<void(void)>> pending_callbacks_;
+  std::vector<EventCallback> pending_callbacks_;
   void flushPendingCallbacks();
 
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
@@ -182,8 +183,9 @@ private:
   std::string id_;
   std::string instance_id_;
   std::string sister_instance_id_;
-  std::function<void(void)> on_broken_;
-  std::function<void(void)> on_formed_;
+  EventCallback on_broken_;
+  EventCallback on_formed_;
+
   bool sisterDiedFirst_;
   bool started_;
   bool connect_timer_reset_flag_;
@@ -201,9 +203,7 @@ private:
   rclcpp::Subscription<bond::msg::Status>::SharedPtr sub_;
   rclcpp::Publisher<bond::msg::Status>::SharedPtr pub_;
 };
-
 }  // namespace bond
-
 
 // Internal use only
 struct BondSM

--- a/bondcpp/include/bondcpp/bond.hpp
+++ b/bondcpp/include/bondcpp/bond.hpp
@@ -117,23 +117,27 @@ public:
 
   void setupConnections();
 
-  double getConnectTimeout() const {return connect_timeout_;}
+  double getConnectTimeout() const {return connect_timeout_.seconds();}
   void setConnectTimeout(double dur);
   void connectTimerReset();
   void connectTimerCancel();
-  double getDisconnectTimeout() const {return disconnect_timeout_;}
+
+  double getDisconnectTimeout() const {return disconnect_timeout_.seconds();}
   void setDisconnectTimeout(double dur);
   void disconnectTimerReset();
   void disconnectTimerCancel();
-  double getHeartbeatTimeout() const {return heartbeat_timeout_;}
+
+  double getHeartbeatTimeout() const {return heartbeat_timeout_.seconds();}
   void setHeartbeatTimeout(double dur);
   void heartbeatTimerReset();
   void heartbeatTimerCancel();
-  double getHeartbeatPeriod() const {return heartbeat_period_;}
+
+  double getHeartbeatPeriod() const {return heartbeat_period_.seconds();}
   void setHeartbeatPeriod(double dur);
   void publishingTimerReset();
   void publishingTimerCancel();
-  double getDeadPublishPeriod() const {return dead_publish_period_;}
+
+  double getDeadPublishPeriod() const {return dead_publish_period_.seconds();}
   void setDeadPublishPeriod(double dur);
   void deadpublishingTimerReset();
   void deadpublishingTimerCancel();
@@ -223,11 +227,11 @@ private:
   bool deadpublishing_timer_reset_flag_ {false};
   bool disable_heartbeat_timeout_ {false};
 
-  double connect_timeout_;
-  double heartbeat_timeout_;
-  double disconnect_timeout_;
-  double heartbeat_period_;
-  double dead_publish_period_;
+  rclcpp::Duration connect_timeout_;
+  rclcpp::Duration disconnect_timeout_;
+  rclcpp::Duration heartbeat_timeout_;
+  rclcpp::Duration heartbeat_period_;
+  rclcpp::Duration dead_publish_period_;
 
   rclcpp::Subscription<bond::msg::Status>::SharedPtr sub_;
   rclcpp::Publisher<bond::msg::Status>::SharedPtr pub_;

--- a/bondcpp/include/bondcpp/bond.hpp
+++ b/bondcpp/include/bondcpp/bond.hpp
@@ -178,9 +178,9 @@ public:
    */
   void breakBond();
 
-  std::string getTopic() {return topic_;}
-  std::string getId() {return id_;}
-  std::string getInstanceId() {return instance_id_;}
+  std::string getTopic() const {return topic_;}
+  std::string getId() const {return id_;}
+  std::string getInstanceId() const {return instance_id_;}
 
 private:
   friend struct ::BondSM;

--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -539,7 +539,6 @@ void Bond::bondStatusCB(const bond::msg::Status & msg)
 
 void Bond::doPublishing()
 {
-  std::unique_lock<std::mutex> lock(state_machine_mutex_);
   if (isStateWaitingForSister() || isStateAlive()) {
     publishStatus(true);
   } else if (isStateAwaitSisterDeath()) {

--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -71,8 +71,8 @@ static std::string makeUUID()
 Bond::Bond(
   const std::string & topic, const std::string & id,
   rclcpp_lifecycle::LifecycleNode::SharedPtr nh,
-  std::function<void(void)> on_broken,
-  std::function<void(void)> on_formed)
+  EventCallback on_broken,
+  EventCallback on_formed)
 : bondsm_(new BondSM(this)),
   sm_(*bondsm_),
   topic_(topic),
@@ -108,8 +108,8 @@ Bond::Bond(
 Bond::Bond(
   const std::string & topic, const std::string & id,
   rclcpp::Node::SharedPtr nh,
-  std::function<void(void)> on_broken,
-  std::function<void(void)> on_formed)
+  EventCallback on_broken,
+  EventCallback on_formed)
 : bondsm_(new BondSM(this)),
   sm_(*bondsm_),
   topic_(topic),
@@ -380,13 +380,13 @@ void Bond::start()
   started_ = true;
 }
 
-void Bond::setFormedCallback(std::function<void(void)> on_formed)
+void Bond::setFormedCallback(EventCallback on_formed)
 {
   std::unique_lock<std::mutex> lock(mutex_);
   on_formed_ = on_formed;
 }
 
-void Bond::setBrokenCallback(std::function<void(void)> on_broken)
+void Bond::setBrokenCallback(EventCallback on_broken)
 {
   std::unique_lock<std::mutex> lock(mutex_);
   on_broken_ = on_broken;
@@ -545,7 +545,7 @@ void Bond::publishStatus(bool active)
 
 void Bond::flushPendingCallbacks()
 {
-  std::vector<std::function<void(void)>> callbacks;
+  std::vector<EventCallback> callbacks;
   {
     std::unique_lock<std::mutex> lock(mutex_);
     callbacks = pending_callbacks_;

--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -563,7 +563,6 @@ void Bond::flushPendingCallbacks()
 void BondSM::Connected()
 {
   b->connectTimerCancel();
-  b->condition_.notify_all();
   if (b->on_formed_) {
     b->pending_callbacks_.push_back(b->on_formed_);
   }
@@ -576,7 +575,6 @@ void BondSM::SisterDied()
 
 void BondSM::Death()
 {
-  b->condition_.notify_all();
   b->heartbeatTimerCancel();
   b->disconnectTimerCancel();
   if (b->on_broken_) {

--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -360,7 +360,6 @@ void Bond::start()
   connect_timer_reset_flag_ = true;
   connectTimerReset();
   publishingTimerReset();
-  heartbeatTimerReset();
   disconnectTimerReset();
   //  deadpublishingTimerReset();
   started_ = true;


### PR DESCRIPTION
Replaces #76 

Split out into multiple commits for easier reviews:

*  Remove a condition variable that wasn't used https://github.com/ros/bond_core/commit/c66eaf3c2bb09ec4b4c5175c737a0e084b81bc4f
* Use a type alias rather than std::function https://github.com/ros/bond_core/commit/f6471a506b237841a7c2bd8716612a18f856f315
* Use a delegating constructor and default initialization to reduce some boilerplate  https://github.com/ros/bond_core/commit/14986f9a61d3189f13f63a1fa8671f39efdcca00
* Improve locking by separating the state machine locks from the pending callbacks lock, as well as reducing the scope of locks wherever possible https://github.com/ros/bond_core/commit/5c7b65c4af59ae6a3f14bd135c4b99a583846f29
* Other test improvements from #76 