### PR TITLE
Update bond_core to modern cmake.

### DIFF
--- a/bondcpp/CMakeLists.txt
+++ b/bondcpp/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(bondcpp)
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -31,33 +31,35 @@ add_library(${PROJECT_NAME}
   src/BondSM_sm.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
   ${UUID_INCLUDE_DIRS})
 if(WIN32)
   target_compile_definitions(${PROJECT_NAME}
     PRIVATE "BONDCPP_BUILDING_LIBRARY" "NOMINMAX")
 endif()
-ament_target_dependencies(${PROJECT_NAME}
-  bond
-  rclcpp
-  rclcpp_lifecycle
-  smclib)
-target_link_libraries(${PROJECT_NAME} ${uuid_ABS_PATH})
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${bond_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  smclib::smclib_header
+)
+target_link_libraries(${PROJECT_NAME} PRIVATE ${uuid_ABS_PATH})
 
 install(
   TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
 
 install(
   DIRECTORY include/
-  DESTINATION include)
+  DESTINATION include/${PROJECT_NAME})
 
-ament_export_dependencies(ament_cmake)
 ament_export_dependencies(bond rclcpp rclcpp_lifecycle smclib)
-ament_export_include_directories(include)
+ament_export_include_directories(include/${PROJECT_NAME})
 ament_export_libraries(${PROJECT_NAME})
+ament_export_targets(${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -65,4 +67,3 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 ament_package()
-

--- a/smclib/CMakeLists.txt
+++ b/smclib/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(smclib)
 
-# Support C++14
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
@@ -14,19 +15,19 @@ find_package(ament_cmake_python REQUIRED)
 add_library(smclib_header INTERFACE)
 target_include_directories(smclib_header INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 
 install(
   TARGETS smclib_header
+  EXPORT smclib_header
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include
 )
 
 install(
   DIRECTORY include/
-  DESTINATION include)
+  DESTINATION include/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -36,8 +37,8 @@ endif()
 
 ament_python_install_package(${PROJECT_NAME})
 
-ament_export_dependencies(ament_cmake)
-ament_export_include_directories(include)
+ament_export_include_directories(include/${PROJECT_NAME})
+ament_export_targets(smclib_header)
 
 ament_package()
 


### PR DESCRIPTION
In particular, make sure it exports targets so downstream users can use those.

While we are here, migrate away from ament_target_dependencies, update to C++17, and move the includes down one directory level (for better workspace overlay support).