### PR TITLE
memory safe subscription callback

### DIFF
--- a/bondcpp/include/bondcpp/bond.hpp
+++ b/bondcpp/include/bondcpp/bond.hpp
@@ -55,7 +55,7 @@ namespace bond
  * another process and be notified when it dies.  In turn, it will be
  * notified when you die.
  */
-class Bond
+class Bond : public std::enable_shared_from_this<Bond>
 {
 public:
   using EventCallback = std::function<void (void)>;
@@ -239,7 +239,9 @@ private:
 
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_;
+  rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_params_;
   rclcpp::node_interfaces::NodeTimersInterface::SharedPtr node_timers_;
+  rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_;
 
   rclcpp::TimerBase::SharedPtr connect_timer_;
   rclcpp::TimerBase::SharedPtr disconnect_timer_;
@@ -274,6 +276,7 @@ private:
   rclcpp::Duration heartbeat_period_;
   rclcpp::Duration dead_publish_period_;
 
+  rclcpp::CallbackGroup::SharedPtr sub_callback_group_;
   rclcpp::Subscription<bond::msg::Status>::SharedPtr sub_;
   rclcpp::Publisher<bond::msg::Status>::SharedPtr pub_;
 };

--- a/bondcpp/include/bondcpp/createSafeCallback.hpp
+++ b/bondcpp/include/bondcpp/createSafeCallback.hpp
@@ -1,6 +1,34 @@
+// Copyright (c) 2009, Willow Garage, Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Willow Garage nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
-#ifndef BONDCPP__CREATE_SAFE_CALLBACK_HPP_
-#define BONDCPP__CREATE_SAFE_CALLBACK_HPP_
+/** \author Mike Wake */
+#ifndef BONDCPP__CREATESAFECALLBACK_HPP_
+#define BONDCPP__CREATESAFECALLBACK_HPP_
 
 #include <memory>
 #include <type_traits>
@@ -8,18 +36,18 @@
 // Expects obj to inhert from std::enable_shared_from_this
 template<typename T, typename MessageT>
 auto createSafeSubscriptionMemFuncCallback(
-    std::shared_ptr<T> obj,
-    void (T::*memberFunc)(const MessageT &)
-) {
+  std::shared_ptr<T> obj,
+  void (T::*memberFunc)(const MessageT &))
+{
   static_assert(std::is_base_of_v<std::enable_shared_from_this<T>, T>,
     "Type expected to inherit from std::enable_shared_from_this");
 
   std::weak_ptr<T> weak_obj = obj;
   return [weak_obj, memberFunc](const MessageT & msg) {
-      if (auto shared_obj = weak_obj.lock()) {
-          ((*shared_obj).*memberFunc)(msg);
-      }
-  };
+           if (auto shared_obj = weak_obj.lock()) {
+             ((*shared_obj).*memberFunc)(msg);
+           }
+         };
 }
 
-#endif // BONDCPP__CREATE_SAFE_CALLBACK_HPP_
+#endif  // BONDCPP__CREATESAFECALLBACK_HPP_

--- a/bondcpp/include/bondcpp/createSafeCallback.hpp
+++ b/bondcpp/include/bondcpp/createSafeCallback.hpp
@@ -1,0 +1,25 @@
+
+#ifndef BONDCPP__CREATE_SAFE_CALLBACK_HPP_
+#define BONDCPP__CREATE_SAFE_CALLBACK_HPP_
+
+#include <memory>
+#include <type_traits>
+
+// Expects obj to inhert from std::enable_shared_from_this
+template<typename T, typename MessageT>
+auto createSafeSubscriptionMemFuncCallback(
+    std::shared_ptr<T> obj,
+    void (T::*memberFunc)(const MessageT &)
+) {
+  static_assert(std::is_base_of_v<std::enable_shared_from_this<T>, T>,
+    "Type expected to inherit from std::enable_shared_from_this");
+
+  std::weak_ptr<T> weak_obj = obj;
+  return [weak_obj, memberFunc](const MessageT & msg) {
+      if (auto shared_obj = weak_obj.lock()) {
+          ((*shared_obj).*memberFunc)(msg);
+      }
+  };
+}
+
+#endif // BONDCPP__CREATE_SAFE_CALLBACK_HPP_

--- a/bondcpp/include/bondcpp/createSafeCallback.hpp
+++ b/bondcpp/include/bondcpp/createSafeCallback.hpp
@@ -37,9 +37,10 @@
 template<typename T, typename MessageT>
 auto createSafeSubscriptionMemFuncCallback(
   std::shared_ptr<T> obj,
-  void (T::*memberFunc)(const MessageT &))
+  void (T::* memberFunc)(const MessageT &))
 {
-  static_assert(std::is_base_of_v<std::enable_shared_from_this<T>, T>,
+  static_assert(
+    std::is_base_of_v<std::enable_shared_from_this<T>, T>,
     "Type expected to inherit from std::enable_shared_from_this");
 
   std::weak_ptr<T> weak_obj = obj;

--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -81,7 +81,9 @@ Bond::Bond(
   EventCallback on_formed)
 : node_base_(node_base),
   node_logging_(node_logging),
+  node_params_(node_params),
   node_timers_(node_timers),
+  node_topics_(node_topics),
   bondsm_(std::make_unique<BondSM>(this)),
   sm_(*bondsm_),
   topic_(topic),
@@ -100,29 +102,23 @@ Bond::Bond(
   dead_publish_period_(
     rclcpp::Duration::from_seconds(bond::msg::Constants::DEAD_PUBLISH_PERIOD))
 {
-  if (!node_params->has_parameter(bond::msg::Constants::DISABLE_HEARTBEAT_TIMEOUT_PARAM)) {
-    node_params->declare_parameter(
+  if (!node_params_->has_parameter(bond::msg::Constants::DISABLE_HEARTBEAT_TIMEOUT_PARAM)) {
+    node_params_->declare_parameter(
       bond::msg::Constants::DISABLE_HEARTBEAT_TIMEOUT_PARAM,
       rclcpp::ParameterValue(false));
   }
 
   disable_heartbeat_timeout_ =
-    node_params->get_parameter(bond::msg::Constants::DISABLE_HEARTBEAT_TIMEOUT_PARAM).as_bool();
+    node_params_->get_parameter(bond::msg::Constants::DISABLE_HEARTBEAT_TIMEOUT_PARAM).as_bool();
 
   setupConnections();
 
   pub_ = rclcpp::create_publisher<bond::msg::Status>(
-    node_params,
-    node_topics,
+    node_params_,
+    node_topics_,
     topic_,
     rclcpp::QoS(rclcpp::KeepLast(5)));
 
-  sub_ = rclcpp::create_subscription<bond::msg::Status>(
-    node_params,
-    node_topics,
-    topic_,
-    rclcpp::QoS(100),
-    std::bind(&Bond::bondStatusCB, this, std::placeholders::_1));
 }
 
 Bond::Bond(
@@ -364,6 +360,30 @@ void Bond::deadpublishingTimerCancel()
 
 void Bond::start()
 {
+  // Need to move subcriber setup here(out of constructor)
+  // to allow usage of weak_from_this()
+
+  if (!started_) {
+    // TBD: Should recreation of subscription be prevented?
+
+    std::weak_ptr<Bond> weakThis = weak_from_this();
+
+    sub_ = rclcpp::create_subscription<bond::msg::Status>(
+      node_params_,
+      node_topics_,
+      topic_,
+      rclcpp::QoS(100),
+      [weakThis](const bond::msg::Status & msg) {
+        if (auto strongThis = weakThis.lock()) {
+          strongThis->bondStatusCB(msg);
+        } else {
+          // Object has gone out of scope, handle accordingly
+        }
+      });
+  } else {
+    RCLCPP_WARN(node_logging_->get_logger(), "start() already started skipping subscription recreation");
+  }
+
   connect_timer_reset_flag_ = true;
   connectTimerReset();
   publishingTimerReset();

--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -375,7 +375,8 @@ void Bond::start()
         &Bond::bondStatusCB)
     );
   } else {
-    RCLCPP_WARN(node_logging_->get_logger(),
+    RCLCPP_WARN(
+      node_logging_->get_logger(),
       "start() already started skipping subscription recreation");
   }
 
@@ -574,7 +575,7 @@ void Bond::publishStatus(bool active)
   msg->active = active;
   msg->heartbeat_timeout = static_cast<float>(heartbeat_timeout_.seconds());
   msg->heartbeat_period = static_cast<float>(heartbeat_period_.seconds());
-  if(pub_->get_subscription_count() < 1){ return; }
+  if (pub_->get_subscription_count() < 1) {return;}
   pub_->publish(std::move(msg));
 }
 

--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -119,7 +119,6 @@ Bond::Bond(
     node_topics_,
     topic_,
     rclcpp::QoS(rclcpp::KeepLast(5)));
-
 }
 
 Bond::Bond(
@@ -373,8 +372,8 @@ void Bond::start()
       rclcpp::QoS(100),
       createSafeSubscriptionMemFuncCallback(
         shared_from_this(),
-        &Bond::bondStatusCB
-      ));
+        &Bond::bondStatusCB)
+    );
   } else {
     RCLCPP_WARN(node_logging_->get_logger(),
       "start() already started skipping subscription recreation");

--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -565,16 +565,17 @@ void Bond::doPublishing()
 
 void Bond::publishStatus(bool active)
 {
-  bond::msg::Status msg;
+  auto msg = std::make_unique<bond::msg::Status>();
   rclcpp::Clock steady_clock(RCL_STEADY_TIME);
   rclcpp::Time now = steady_clock.now();
-  msg.header.stamp = now;
-  msg.id = id_;
-  msg.instance_id = instance_id_;
-  msg.active = active;
-  msg.heartbeat_timeout = static_cast<float>(heartbeat_timeout_.seconds());
-  msg.heartbeat_period = static_cast<float>(heartbeat_period_.seconds());
-  pub_->publish(msg);
+  msg->header.stamp = now;
+  msg->id = id_;
+  msg->instance_id = instance_id_;
+  msg->active = active;
+  msg->heartbeat_timeout = static_cast<float>(heartbeat_timeout_.seconds());
+  msg->heartbeat_period = static_cast<float>(heartbeat_period_.seconds());
+  if(pub_->get_subscription_count() < 1){ return; }
+  pub_->publish(std::move(msg));
 }
 
 void Bond::flushPendingCallbacks()

--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -29,6 +29,7 @@
 // Author: Stuart Glaser
 
 #include <bondcpp/bond.hpp>
+#include <bondcpp/createSafeCallback.hpp>
 
 #ifdef _WIN32
 #include <Rpc.h>
@@ -360,28 +361,23 @@ void Bond::deadpublishingTimerCancel()
 
 void Bond::start()
 {
-  // Need to move subcriber setup here(out of constructor)
-  // to allow usage of weak_from_this()
+  // create_subscription must be done outside of constructor
+  // to allow usage of shared_from_this()
 
+  // TBD: Should recreation of subscription be prevented?
   if (!started_) {
-    // TBD: Should recreation of subscription be prevented?
-
-    std::weak_ptr<Bond> weakThis = weak_from_this();
-
     sub_ = rclcpp::create_subscription<bond::msg::Status>(
       node_params_,
       node_topics_,
       topic_,
       rclcpp::QoS(100),
-      [weakThis](const bond::msg::Status & msg) {
-        if (auto strongThis = weakThis.lock()) {
-          strongThis->bondStatusCB(msg);
-        } else {
-          // Object has gone out of scope, handle accordingly
-        }
-      });
+      createSafeSubscriptionMemFuncCallback(
+        shared_from_this(),
+        &Bond::bondStatusCB
+      ));
   } else {
-    RCLCPP_WARN(node_logging_->get_logger(), "start() already started skipping subscription recreation");
+    RCLCPP_WARN(node_logging_->get_logger(),
+      "start() already started skipping subscription recreation");
   }
 
   connect_timer_reset_flag_ = true;

--- a/test_bond/test/test_callbacks_cpp.cpp
+++ b/test_bond/test/test_callbacks_cpp.cpp
@@ -83,15 +83,15 @@ TEST_F(TestCallbacksCpp, dieInLifeCallback)
 {
   auto nh1 = rclcpp::Node::make_shared("test_callbacks_cpp");
   std::string id1 = genId();
-  bond::Bond a(TOPIC, id1, nh1);
-  bond::Bond b(TOPIC, id1, nh1);
+  auto a = std::make_shared<bond::Bond>(TOPIC, id1, nh1);
+  auto b = std::make_shared<bond::Bond>(TOPIC, id1, nh1);
 
-  a.setFormedCallback(
+  a->setFormedCallback(
     [&a]() {
-      a.breakBond();
+      a->breakBond();
     });
-  a.start();
-  b.start();
+  a->start();
+  b->start();
 
   std::atomic<bool> isRunning {true};
   auto runThread = std::thread(
@@ -101,8 +101,8 @@ TEST_F(TestCallbacksCpp, dieInLifeCallback)
       }
     });
 
-  EXPECT_TRUE(a.waitUntilFormed(rclcpp::Duration(5.0s)));
-  EXPECT_TRUE(b.waitUntilBroken(rclcpp::Duration(3.0s)));
+  EXPECT_TRUE(a->waitUntilFormed(rclcpp::Duration(5.0s)));
+  EXPECT_TRUE(b->waitUntilBroken(rclcpp::Duration(3.0s)));
 
   isRunning = false;
   runThread.join();
@@ -112,9 +112,9 @@ TEST_F(TestCallbacksCpp, remoteNeverConnects)
 {
   auto nh2 = rclcpp::Node::make_shared("test_callbacks_cpp_2");
   std::string id2 = genId();
-  bond::Bond a1(TOPIC, id2, nh2);
+  auto a1 = std::make_shared<bond::Bond>(TOPIC, id2, nh2);
 
-  a1.start();
+  a1->start();
 
   std::atomic<bool> isRunning {true};
   auto runThread = std::thread(

--- a/test_bond/test/test_callbacks_cpp.cpp
+++ b/test_bond/test/test_callbacks_cpp.cpp
@@ -124,8 +124,8 @@ TEST_F(TestCallbacksCpp, remoteNeverConnects)
       }
     });
 
-  EXPECT_FALSE(a1.waitUntilFormed(rclcpp::Duration(4.0s)));
-  EXPECT_TRUE(a1.waitUntilBroken(rclcpp::Duration(10.0s)));
+  EXPECT_FALSE(a1->waitUntilFormed(rclcpp::Duration(4.0s)));
+  EXPECT_TRUE(a1->waitUntilBroken(rclcpp::Duration(10.0s)));
 
   isRunning = false;
   runThread.join();


### PR DESCRIPTION
Manage the lifetime of the bondStatusCB member function by wrapping it in a lambda that captures a weak_ptr (via public inheritance of std::enable_shared_from_this)

NOTE: 
This is a draft to show how it could be done.  

It solves a use after free that is being experienced using intraprocess communication in nav2 https://github.com/ros-navigation/navigation2/issues/4691 .  

Also being discussed as a bug in rclcpp - https://github.com/ros2/rclcpp/issues/2678#issuecomment-2583472585

Something like createSafeSubscriptionMemFuncCallback could make its way into the rclcpp namespace.