### PR TITLE
Do not include windows.h in statemap.hpp

### DIFF
--- a/smclib/include/smclib/statemap.hpp
+++ b/smclib/include/smclib/statemap.hpp
@@ -52,7 +52,6 @@
 #endif  // SMC_NO_EXCEPTIONS
 #include <cstdio>
 #elif defined(WIN32)
-#include <windows.h>
 #if defined(SMC_NO_EXCEPTIONS)
 #include <cassert>
 #endif  // SMC_NO_EXCEPTIONS

--- a/smclib/include/smclib/statemap.hpp
+++ b/smclib/include/smclib/statemap.hpp
@@ -46,24 +46,12 @@
 #ifndef SMCLIB__STATEMAP_HPP_
 #define SMCLIB__STATEMAP_HPP_
 
-#if (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1))
 #if defined(SMC_NO_EXCEPTIONS)
 #include <cassert>
-#endif  // SMC_NO_EXCEPTIONS
 #include <cstdio>
-#elif defined(WIN32)
-#if defined(SMC_NO_EXCEPTIONS)
-#include <cassert>
-#endif  // SMC_NO_EXCEPTIONS
 #else
-#if defined(SMC_NO_EXCEPTIONS)
-#include <assert.h>
-#endif  // SMC_NO_EXCEPTIONS
-#include <stdio.h>
-#endif
-#if !defined(SMC_NO_EXCEPTIONS)
-#include <stdexcept>
 #include <cstring>
+#include <stdexcept>
 #endif
 
 #include <string>


### PR DESCRIPTION
Including `windows.h` in a public header may screw up any call to `std::min`, `std::max` or any enum called `ERROR` (that are quite frequent). Apparently this specific include is unused (see https://github.com/ros/bond_core/pull/46) so we can safely remove it.