### PR TITLE
Check the availability of mutex before locking it.

### DIFF
--- a/bondcpp/src/bond.cpp
+++ b/bondcpp/src/bond.cpp
@@ -566,9 +566,15 @@ void Bond::flushPendingCallbacks()
 {
   std::vector<EventCallback> callbacks;
   {
-    std::unique_lock<std::mutex> lock(callbacks_mutex_);
-    callbacks = pending_callbacks_;
-    pending_callbacks_.clear();
+    // Check the availability of the mutex before locking
+    // This is a temporary fix before https://github.com/ros/bond_core/pull/108 is merged
+    if (callbacks_mutex_.try_lock()) {
+      callbacks = pending_callbacks_;
+      pending_callbacks_.clear();
+      callbacks_mutex_.unlock();
+    } else {
+      return;
+    }
   }
 
   for (size_t i = 0; i < callbacks.size(); ++i) {


### PR DESCRIPTION
Temporary fix for the issue https://github.com/ros2/rmw_zenoh/issues/532
I think it would be great if we could have a more comprehensive solution on https://github.com/ros/bond_core/pull/108
But before that, we can have this patch to avoid potential panic on navigation2 with rmw_zenoh.