### PR TITLE
fix ParameterAlreadyDeclaredException in _on_heartbeat_timeout

### DIFF
--- a/bondpy/bondpy/bondpy.py
+++ b/bondpy/bondpy/bondpy.py
@@ -34,6 +34,7 @@ import uuid
 
 from bond.msg import Constants, Status
 from bondpy.BondSM_sm import BondSM_sm
+from rclpy.exceptions import ParameterAlreadyDeclaredException
 
 import rclpy
 from rclpy.duration import Duration
@@ -184,7 +185,11 @@ class Bond(object):
 
     def _on_heartbeat_timeout(self):
         # Checks that heartbeat timeouts haven't been disabled globally
-        self.node.declare_parameter(Constants.DISABLE_HEARTBEAT_TIMEOUT_PARAM, False)
+        try:
+            if not self.node.has_parameter(Constants.DISABLE_HEARTBEAT_TIMEOUT_PARAM):
+                self.node.declare_parameter(Constants.DISABLE_HEARTBEAT_TIMEOUT_PARAM, False)
+        except ParameterAlreadyDeclaredException:
+            pass
         disable_heartbeat_timeout = self.node.get_parameter(
             Constants.DISABLE_HEARTBEAT_TIMEOUT_PARAM).value
         if disable_heartbeat_timeout:

--- a/bondpy/bondpy/bondpy.py
+++ b/bondpy/bondpy/bondpy.py
@@ -34,10 +34,10 @@ import uuid
 
 from bond.msg import Constants, Status
 from bondpy.BondSM_sm import BondSM_sm
-from rclpy.exceptions import ParameterAlreadyDeclaredException
 
 import rclpy
 from rclpy.duration import Duration
+from rclpy.exceptions import ParameterAlreadyDeclaredException
 
 
 def duration_to_sec(duration):


### PR DESCRIPTION
When a bond times out and after that a new bond is created which also times out, the following exception occurs: 

``` bash 
Exception in thread Thread-121:
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 1378, in run
    self.function(*self.args, **self.kwargs)
  File "/opt/ros/humble/lib/python3.10/site-packages/bondpy/bondpy.py", line 85, in _on_timer
    self.on_timeout()
  File "/opt/ros/humble/lib/python3.10/site-packages/bondpy/bondpy.py", line 187, in _on_heartbeat_timeout
    self.node.declare_parameter(Constants.DISABLE_HEARTBEAT_TIMEOUT_PARAM, False)
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/node.py", line 367, in declare_parameter
    return self.declare_parameters('', [args], ignore_override)[0]
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/node.py", line 490, in declare_parameters
    raise ParameterAlreadyDeclaredException(parameters_already_declared)
rclpy.exceptions.ParameterAlreadyDeclaredException: ('Parameter(s) already declared', ['/bond_disable_heartbeat_timeout'])
``` 

By guarding against `ParameterAlreadyDeclaredException` this can be easily handled. 